### PR TITLE
Fix to reuse redis connection

### DIFF
--- a/lib/slaq/redis.rb
+++ b/lib/slaq/redis.rb
@@ -49,7 +49,7 @@ module Slaq
     end
 
     def redis
-      redis ||= ::Redis.new(url: ENV['REDIS_URL'])
+      @redis ||= ::Redis.new(url: ENV['REDIS_URL'])
     end
   end
 end


### PR DESCRIPTION
## 背景
heroku redisで `Redis::CommandError: ERR max number of clients reached `
原因を調査したところ -> :bug: redisへの接続の保持をインスタンス変数にしていなかった。