### PR TITLE
Adujst post interval

### DIFF
--- a/lib/slaq/slack.rb
+++ b/lib/slaq/slack.rb
@@ -8,6 +8,8 @@ module Slaq
   class Slack
     include Slaq::Slack::Quiz
 
+    POST_INTERVAL = 0.1
+
     ::Slack::RealTime::Client.configure do |config|
       config.token = ENV['SLAQ_RTM_API_TOKEN']
       config.logger = Logger.new(STDOUT)

--- a/lib/slaq/slack/quiz.rb
+++ b/lib/slaq/slack/quiz.rb
@@ -23,6 +23,7 @@ module Slaq
             case signal
             when 'continue'
               posted_chars += chars
+              sleep Slaq::Slack::POST_INTERVAL
               client.web_client.chat_update(channel: channel, text: posted_chars, ts: last_post_ts)
             when 'next'
               break


### PR DESCRIPTION
## 背景
herokuで動かしたところ（おそらく）レイテンシの改善によりslackのテキストの編集が高速になってしまった。速度を調整する。

## 対応
ポストするときにsleepをいれる。