### PR TITLE
Fix re-post after wrong answer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 /tmp/
 
 # Used by dotenv library to load environment variables.
-# .env
+.env
 
 ## Specific to RubyMotion:
 .dat*

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,8 +10,8 @@ services:
     stdin_open: true
     volumes:
       - "../:/app"
+    env_file: ../.env
     environment:
-      SLAQ_RTM_API_TOKEN: xoxb-2451879749-380909465317-MBExdc01EGkS0zQsuBbq4I46
       REDIS_URL: redis://redis:6379
     depends_on:
       - redis

--- a/lib/slaq/slack.rb
+++ b/lib/slaq/slack.rb
@@ -47,7 +47,7 @@ module Slaq
             post_answer(data.channel, question, answer, wiki_link)
             post_correct(data.channel)
           else
-            redis.set_signal('continue') unless redis.get_signal == 'next'
+            redis.set_signal('continue') if redis.get_signal != 'next'
             respondant = 'anonymous'
             post_wrong(data.channel)
           end
@@ -69,7 +69,7 @@ module Slaq
           end
         when 'a'
           if (during_quiz && respondant == 'anonymous') || time_taken_to_answer > Slaq::Quiz::ANSWER_LIMIT_TIME
-            redis.set_signal('pause')
+            redis.set_signal('pause') if redis.get_signal == 'continue'
             post_urge_the_answer(data.channel, data.user)
             respondant = data.user
             time_pressed_a = data.ts.to_i

--- a/lib/slaq/slack.rb
+++ b/lib/slaq/slack.rb
@@ -47,7 +47,7 @@ module Slaq
             post_answer(data.channel, question, answer, wiki_link)
             post_correct(data.channel)
           else
-            redis.set_signal('continue')
+            redis.set_signal('continue') unless redis.get_signal == 'next'
             respondant = 'anonymous'
             post_wrong(data.channel)
           end


### PR DESCRIPTION
## 背景
問題文の投稿が終わったあとに誤回答をすると再び問題文が最初から投稿されてしまっていた。

## 対応
問題文の投稿が終わっていた場合シグナルを更新しない用に変更。