### PR TITLE
クイズ保存機能を追加

### DIFF
--- a/lib/slaq/slack.rb
+++ b/lib/slaq/slack.rb
@@ -81,6 +81,10 @@ module Slaq
             respondant = 'anonymous'
             during_quiz = nil
           end
+        when 's'
+          unless question.nil?
+            post_answer(data.user, question, answer, wiki_link)
+          end
         end
       end
 

--- a/lib/slaq/slack.rb
+++ b/lib/slaq/slack.rb
@@ -8,6 +8,7 @@ module Slaq
   class Slack
     include Slaq::Slack::Quiz
 
+    COMMANDS = %w(q a g s)
     POST_INTERVAL = 0.1
 
     ::Slack::RealTime::Client.configure do |config|
@@ -39,7 +40,7 @@ module Slaq
 
       client.on :message do |data|
         time_taken_to_answer = data.ts.to_i - time_pressed_a
-        if data.text != 'g' && data.text != 'q' && data.user == respondant && time_taken_to_answer < Slaq::Quiz::ANSWER_LIMIT_TIME
+        if !Slaq::Slack::COMMANDS.include?(data.text) && data.user == respondant && time_taken_to_answer < Slaq::Quiz::ANSWER_LIMIT_TIME
           if data.text == answer
             redis.set_signal('next')
             respondant = 'anonymous'


### PR DESCRIPTION
## 背景
クイズを保存しておける機能を追加した。あとから見返せるように `s` を押したときにDMに問題文と答えを送る

## 対応
- 's'コマンドを実装
- コマンドを答えとして認識しないように修正