### PR TITLE
Restrict to answer to one time only

### DIFF
--- a/lib/slaq/quiz.rb
+++ b/lib/slaq/quiz.rb
@@ -1,10 +1,31 @@
+require_relative 'quiz/respondent'
+require_relative 'quiz/status'
+require_relative 'wikipedia'
+
 module Slaq
   class Quiz
+    include Slaq::Quiz::Respondent
+    include Slaq::Quiz::Status
+
     ANSWER_LIMIT_TIME=10.freeze
+
+    attr_accessor :question, :answer, :wiki_link, :status, :respondent, :time_pressed_a, :revoked_users
+
+    def initialize
+      @question = nil
+      @answer = nil
+      @wiki_link = nil
+      @status = nil
+      @respondent = 'anonymous'
+      @time_pressed_a = nil
+      @revoked_users = []
+    end
 
     def random
       get_quizzes_from_text_file.sample
     end
+
+    private
 
     def get_quizzes_from_text_file
       quizzes_dir_path = File.expand_path('../../quizzes', __dir__)

--- a/lib/slaq/redis.rb
+++ b/lib/slaq/redis.rb
@@ -8,6 +8,12 @@ module Slaq
       redis.flushdb
     end
 
+    def set_quiz(data, quiz)
+      set_channel(data.channel)
+      set_question(quiz.question)
+      set_answer(quiz.answer)
+    end
+
     def set_question(question)
       redis.set("question", question)
     end
@@ -22,14 +28,6 @@ module Slaq
 
     def get_answer
       redis.get("answer")
-    end
-
-    def set_quiz(quiz)
-      redis.set("quiz", quiz.to_json)
-    end
-
-    def get_quiz
-      redis.get("quiz")
     end
 
     def set_signal(signal)


### PR DESCRIPTION
## 背景
解答できるのを一問につき一回に制限したかった。

## 対応
Slaq::Quizの配列のインスタンス変数へ `s` を押したuserをいれて `a` を押したときにその配列にユーザーが含まれていないかチェックする。
