### PR TITLE
クイズのファイルを読み込むのは最初の一回だけに

### DIFF
--- a/lib/slaq/quiz.rb
+++ b/lib/slaq/quiz.rb
@@ -9,7 +9,7 @@ module Slaq
 
     ANSWER_LIMIT_TIME=10.freeze
 
-    attr_accessor :question, :answer, :wiki_link, :status, :respondent, :time_pressed_a, :revoked_users
+    attr_accessor :question, :answer, :wiki_link, :status, :respondent, :time_pressed_a, :revoked_users, :quizzes
 
     def initialize
       @question = nil
@@ -19,17 +19,19 @@ module Slaq
       @respondent = 'anonymous'
       @time_pressed_a = nil
       @revoked_users = []
+      @quizzes = []
+
+      set_quizzes_from_text_file
     end
 
     def random
-      get_quizzes_from_text_file.sample
+      quizzes.sample
     end
 
     private
 
-    def get_quizzes_from_text_file
+    def set_quizzes_from_text_file
       quizzes_dir_path = File.expand_path('../../quizzes', __dir__)
-      quizzes = []
 
       File.open("#{quizzes_dir_path}/quiz.txt", "r:UTF-8") do |quiz_file|
         quiz_file.each_line do |quiz|
@@ -37,8 +39,6 @@ module Slaq
           quizzes << { quiz: { question: splited[0].chomp, answer: splited[1].chomp } }
         end
       end
-
-      quizzes
     end
   end
 end


### PR DESCRIPTION
今の仕様だと

https://github.com/grezar/slaq/blob/736fe5b7a5beb0fc040af0089f67f1f352c02028/lib/slaq/slack.rb#L57
ここで `#random` が呼ばれるたびに

https://github.com/grezar/slaq/blob/f703de07b03dfa602b47d4a32747036eca1d7eb3/lib/slaq/quiz.rb#L25
`#get_quizzes_from_text_file` が呼ばれているように見えたから

最初に Quiz.new した時に読み込んで、あとはキャッシュした問題を使い回せばいいんじゃないのかな？と思った(読み間違えていたらごめんーー 🐱 )

テスト書いてないから動くかわからんが... 🙀 